### PR TITLE
Style excuse button and BoosterCard component

### DIFF
--- a/src/components/BoosterCard.vue
+++ b/src/components/BoosterCard.vue
@@ -16,10 +16,10 @@
     <div class="booster-card">
         <div class="card-header">
             <h3>{{ type }}.</h3>
-            <p v-if="!booster.isFavorited"
+            <p v-if="!booster.isFavorited && booster.type !== 'excuse'"
                 @click="favoriteBooster(booster)" 
                 class="unfilled-favorite-star star">☆</p>
-            <p v-if="booster.isFavorited" 
+            <p v-if="booster.isFavorited && booster.type !== 'excuse'" 
                 @click="deleteBooster(booster)"
                 class="filled-favorite-star star">★</p>
         </div>

--- a/src/views/RandomView.vue
+++ b/src/views/RandomView.vue
@@ -109,8 +109,11 @@
         :booster="booster"
       />
     </div>
-    <div>
-      <button @click="getNewExcuse">I gotta get out of here</button>
+    <div class="excuse-container">
+      <button class="excuse-button" 
+        @click="getNewExcuse">
+        I gotta get out of here!
+        </button>
       <BoosterCard v-if= "booster && booster.type ==='excuse'" 
         :isFavorited="booster.isFavorited" 
         :text="booster.text" 
@@ -122,6 +125,12 @@
   </div>
 </template>
 <style scoped>
+  .excuse-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+  }
 
   .random {
     margin: 1rem;
@@ -141,6 +150,9 @@
     transition: 0.4s;
   }
 
+  .excuse-button {
+    background-color:#d0121b;
+  }
   .booster-container {
     display: flex;
     justify-content: center;


### PR DESCRIPTION
What does this PR do?
- This branch styled the excuse button a little darker than the boosters to give a sense of urgency
- I removed the favorite stars in the BoosterCard if the card was an excuse since there was no storage of the booster to global state. If we choose to be able to save our excuses, this can easily be changed!
Where should your reviewer start?
- Opening up the app in browser
What (if any) features are you implementing?
- Conditional rendering of the stat buttons
What (if anything) did you refactor?
-
Were there any issues that arose?
-
Is there anything that you need from your teammate?
-
Any other comments, questions, or concerns?
-